### PR TITLE
Switch PDO error mode

### DIFF
--- a/database.php
+++ b/database.php
@@ -19,7 +19,8 @@ class Database
        {      
         try 
         {
-          self::$cont =  new PDO( "mysql:host=".self::$dbHost.";"."dbname=".self::$dbName, self::$dbUsername, self::$dbUserPassword);  
+          self::$cont =  new PDO( "mysql:host=".self::$dbHost.";"."dbname=".self::$dbName, self::$dbUsername, self::$dbUserPassword);
+          self::$cont->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION); //Switch error mode to ensure exceptions fired as they occur
         }
         catch(PDOException $e) 
         {


### PR DESCRIPTION
Switched default error mode from PDO::ERRMODE_SILENT to PDO::ERRMODE_EXCEPTION

Gives more meaningful exception message when table/column not present in database.
